### PR TITLE
changed association between feature and park

### DIFF
--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,3 +1,4 @@
 class Feature < ApplicationRecord
-  belongs_to :park
+  # Rails console does not generate Features array when relation between Park and Feature has a 'belongs_to :park'
+  has_many :park
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,14 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+if Feature.count == 0
+  features = ["all", "accessibple", "basketball", "bbq", "bins", "botanical", "cultural", "educational", "events", "exercise", "fenced", "food nearby", "farm", "grassed", "heritage", "lake", "market", "playground", "river", "seating", "shelter", "skate", "toilets", "velodrome"]
+  features.each do |feature|
+    Feature.create(name: feature)
+    puts "Created #{feature} feature"
+  end
+  puts "Created features"
+end
 
 if Category.count == 0
   categories = ["all", "community", "child friendly", "dog park", "large park", "nature", "skatepark", "sports"]
@@ -13,15 +21,6 @@ if Category.count == 0
     puts "Created #{category} category"
   end
   puts "Created categories"
-end
-
-if Feature.count == 0
-  features = ["all", "accessible", "basketball", "bbq", "bins", "botanical", "cultural", "educational", "events", "exercise", "fenced", "food nearby", "farm", "grassed", "heritage", "lake", "market", "playground", "river", "seating", "shelter", "skate", "toilets", "velodrome"]
-  features.each do |feature|
-    Feature.create(name: feature)
-    puts "Created #{feature} feature"
-  end
-  puts "Created features"
 end
 
 if User.count == 0


### PR DESCRIPTION
When generating seeds, it did not create any for Features. Went through this and discovered that it was the association that did not generate an array in `rails c`. Change `belongs_to :park` to `has_many :park` 
This allowed for Feature data to be generated in `rails c`